### PR TITLE
解决当要上传的文件路径不存在时，使用未定义的filePath造成致命错误

### DIFF
--- a/tencentyun/imagev2.js
+++ b/tencentyun/imagev2.js
@@ -27,6 +27,7 @@ exports.upload = function(fileObj, bucket, fileid, callback, userid, magicContex
     if (fileObj instanceof Buffer) {
         isBuffer = true
     } else if (typeof fileObj == 'string' || fileObj instanceof String) {
+		var filePath=fileObj;
         isExists = fs.existsSync(fileObj)
     }
 


### PR DESCRIPTION
报错信息如下：
![default](https://cloud.githubusercontent.com/assets/13741751/11332955/0faee3ee-9205-11e5-9191-0bf54bcb61a1.png)
